### PR TITLE
Linting

### DIFF
--- a/.eslintcache
+++ b/.eslintcache
@@ -1,1 +1,0 @@
-{"/home/judd/react-chessdiagram/src/piece.js":{"size":15139,"mtime":1478906343431,"hashOfConfig":"1m5d96g","results":{"filePath":"/home/judd/react-chessdiagram/src/piece.js","messages":[],"errorCount":0,"warningCount":0}}}

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,7 @@ module.exports = {
         "browser": true,
         "es6": true
     },
-    "extends": "eslint:recommended",
+    "extends": ["eslint:recommended", "plugin:react/recommended"],
     "parserOptions": {
         "ecmaFeatures": {
             "experimentalObjectRestSpread": true,

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ coverage
 .DS_Store
 .env
 npm-debug.log
+.eslintcache


### PR DESCRIPTION
Extend the linting rules with the very useful `eslint-plugin-react`'s presets. These rules get rid of some of the useless error messages (eg, mistaking components for unused variables) and introduces some useful ones (eg, raising a flag when a prop is missing from validation). Once this merged I'll go through and make sure everything lints properly, which isn't difficult.

Also, ignore `.eslintcache`, because it's not useful to track it (and committing things with information about my local machine's filetree always makes me feel like I've left my curtains open). 