### PR TITLE
Linting and demo

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,6 +30,7 @@ module.exports = {
         "semi": [
             "error",
             "always"
-        ]
+        ],
+        "react/display-name": "off"
     }
 };

--- a/demo/App.css
+++ b/demo/App.css
@@ -2,3 +2,13 @@
 	margin-left: 40px;
 	font-family: sans-serif;
 }
+
+.propGroup {
+	display: inline-block;
+	margin-right: 20px;
+}
+
+.lastMessage {
+	display: inline-block;
+	position: absolute;
+}

--- a/demo/App.js
+++ b/demo/App.js
@@ -22,6 +22,8 @@ class App extends Component {
 			lastMessage: '',
 			squareSize: 45,
 			draughts: false,
+			ranks: 8,
+			files: 8
 		};
 		this.draughtsPieceDefinitions = {
 			'G': (transformString) => (
@@ -72,6 +74,14 @@ class App extends Component {
 		}));
 	}
 
+	_onFilesChanged(evt) {
+		this.setState({files: Number(evt.target.value)});
+	}
+
+	_onRanksChanged(evt) {
+		this.setState({ranks: Number(evt.target.value)});
+	}
+
 // the render() function:
   render() {
     return (
@@ -89,10 +99,13 @@ class App extends Component {
 					<p>Draughts ?<input type="checkbox" value={this.state.draughts} onChange={this._onDraughtsChanged.bind(this)} /></p>
 					<p>Light Square Color:<input type="color" value={this.state.lightSquareColor} onChange={this._onLightSquareColorChanged.bind(this)} /></p>
 					<p>Dark Square Color:<input type="color" value={this.state.darkSquareColor} onChange={this._onDarkSquareColorChanged.bind(this)} /></p>
+					<p>Ranks:<input type="text" value={this.state.ranks} onChange={this._onRanksChanged.bind(this)} /></p>
+					<p>Files:<input type="text" value={this.state.files} onChange={this._onFilesChanged.bind(this)} /></p>
 					<p/>
 				</div>
 					<Chessdiagram flip={this.state.flip} fen={this.state.currentPosition} squareSize={this.state.squareSize}
 						lightSquareColor={this.state.lightSquareColor} darkSquareColor={this.state.darkSquareColor} onMovePiece={this._onMovePiece.bind(this)}
+						ranks={this.state.ranks} files={this.state.files}
 						pieceDefinitions={this.state.draughts ? this.draughtsPieceDefinitions : {}}
 					/>
 				<p><strong>{this.state.lastMessage}</strong></p>

--- a/demo/App.js
+++ b/demo/App.js
@@ -21,24 +21,49 @@ class App extends Component {
 			flip: false,
 			lastMessage: '',
 			squareSize: 45,
-			draughts: false,
+			gameType: 'chess',
 			ranks: 8,
 			files: 8
 		};
-		this.draughtsPieceDefinitions = {
-			'G': (transformString) => (
-				<svg>
-					<image transform={transformString} href="https://upload.wikimedia.org/wikipedia/commons/9/90/Draughts_mlt45.svg" />
-				</svg>
-			),
-			'g': (transformString) => (
-				<svg>
-					<image transform={transformString} href="https://upload.wikimedia.org/wikipedia/commons/0/0c/Draughts_mdt45.svg" />
-				</svg>
-			)
-		};
-		this.draughtsFen = "g1g1g1g1/1g1g1g1g/g1g1g1g1/8/8/1G1G1G1G/G1G1G1G1/1G1G1G1G w KQkq - 0 1";
-		this.standardFen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+		this.gamePresets = {
+			chess: {
+				currentPosition: "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+				ranks: 8,
+				files: 8,
+				pieceDefinitions: {}
+			},
+			draughts: {
+				currentPosition: "1g1g1g1g1g/g1g1g1g1g1/1g1g1g1g1g/g1g1g1g1g1/91/91/1G1G1G1G1G/G1G1G1G1G1/1G1G1G1G1G/G1G1G1G1G1 w - - 0 1",
+				ranks: 10,
+				files: 10,
+				pieceDefinitions: {
+					'G': this._createPieceDefinition("https://upload.wikimedia.org/wikipedia/commons/9/90/Draughts_mlt45.svg"),
+					'g': this._createPieceDefinition("https://upload.wikimedia.org/wikipedia/commons/0/0c/Draughts_mdt45.svg")
+				}
+			},
+			courier: {
+				currentPosition: "rnbcmk1scbnr/1ppppp1pppp1/6q5/p5p4p/P5P4p/6Q5/1PPPPP1PPPP1/RNBCMK1SCBNR",
+				ranks: 8,
+				files: 12,
+				pieceDefinitions: {
+					'C': this._createPieceDefinition("https://upload.wikimedia.org/wikipedia/commons/7/7c/Chess_Blt45.svg"),
+					'c': this._createPieceDefinition("https://upload.wikimedia.org/wikipedia/commons/5/5a/Chess_Bdt45.svg"),
+					'M': this._createPieceDefinition("https://upload.wikimedia.org/wikipedia/commons/1/17/Chess_flt45.svg"),
+					'm': this._createPieceDefinition("https://upload.wikimedia.org/wikipedia/commons/2/2c/Chess_fdt45.svg"),
+					'S': this._createPieceDefinition("https://upload.wikimedia.org/wikipedia/commons/c/ce/Chess_tlt45.svg"),
+					's': this._createPieceDefinition("https://upload.wikimedia.org/wikipedia/commons/e/e2/Chess_tdt45.svg")
+				}
+			}
+		}
+	}
+
+	// Convenience function for concisely creating piece definition callbacks
+	_createPieceDefinition(url) {
+		return (transformString) => (
+			<svg>
+				<image transform={transformString} href={url} />
+			</svg>
+		)
 	}
 
 // event handlers:
@@ -59,16 +84,12 @@ class App extends Component {
 		this.setState({darkSquareColor: evt.target.value});
 	}
 
-	_onDraughtsChanged(evt) {
-		const position = evt.target.checked ? this.draughtsFen : this.standardFen;
-		this.setState({currentPosition: position,   draughts: evt.target.checked})
-	}
-
 	_onMovePiece(piece, fromSquare, toSquare) { // user moved a piece
+		clearTimeout(this.timeout)
 		// echo move back to user:
 		let message = 'You moved ' + piece + fromSquare + " to " + toSquare + ' !';
 		this.setState({lastMessage: message}, (()=> {
-			setTimeout(()=> {
+			this.timeout = setTimeout(()=> {
 					this.setState({lastMessage: ''});
 			}, 2000); // clear message after 2s
 		}));
@@ -82,33 +103,49 @@ class App extends Component {
 		this.setState({ranks: Number(evt.target.value)});
 	}
 
+	_onGameTypeChange(evt) {
+		this.setState(Object.assign(this.gamePresets[evt.target.value], {gameType: evt.target.value}));
+	}
+
 // the render() function:
   render() {
     return (
 			<div className="demo">
 				<h1>Chess Diagram</h1>
 				<div>
-					<p> Enter a position (using a FEN string) here:</p>
-					<input type="text" value={this.state.currentPosition} size="70" onChange={this._onPositionChanged.bind(this)}
-						autoCapitalize="off" autoCorrect="off" autoComplete="off" spellCheck="false"/>
-					<p> Square Size: </p>
-					<input type="range" value={this.state.squareSize} min={10} max={100} step={1} onChange = {evt => {
-						this.setState({squareSize: Number(evt.target.value)});
-					}}/>
-					<p>Flip Board ?<input type="checkbox" value={this.state.flip} onChange={this._onFlipChanged.bind(this)} /></p>
-					<p>Draughts ?<input type="checkbox" value={this.state.draughts} onChange={this._onDraughtsChanged.bind(this)} /></p>
-					<p>Light Square Color:<input type="color" value={this.state.lightSquareColor} onChange={this._onLightSquareColorChanged.bind(this)} /></p>
-					<p>Dark Square Color:<input type="color" value={this.state.darkSquareColor} onChange={this._onDarkSquareColorChanged.bind(this)} /></p>
-					<p>Ranks:<input type="text" value={this.state.ranks} onChange={this._onRanksChanged.bind(this)} /></p>
-					<p>Files:<input type="text" value={this.state.files} onChange={this._onFilesChanged.bind(this)} /></p>
+					<div>
+						<p> Enter a position (using a FEN string) here:</p>
+						<input type="text" value={this.state.currentPosition} size="70" onChange={this._onPositionChanged.bind(this)}
+							autoCapitalize="off" autoCorrect="off" autoComplete="off" spellCheck="false"/>
+					</div>
+					<div className="propGroup">
+						<p> Square Size: </p>
+						<input type="range" value={this.state.squareSize} min={10} max={100} step={1} onChange = {evt => {
+							this.setState({squareSize: Number(evt.target.value)});
+						}}/>
+						<p>Flip Board ?<input type="checkbox" value={this.state.flip} onChange={this._onFlipChanged.bind(this)} /></p>
+						<p>Light Square Color:<input type="color" value={this.state.lightSquareColor} onChange={this._onLightSquareColorChanged.bind(this)} /></p>
+						<p>Dark Square Color:<input type="color" value={this.state.darkSquareColor} onChange={this._onDarkSquareColorChanged.bind(this)} /></p>
+					</div>
+					<div className="propGroup">
+						<p>Game Type:{'\u00A0'}
+							<select name="gameType" value={this.state.gameType} onChange={this._onGameTypeChange.bind(this)}>
+								{Object.keys(this.gamePresets).map(gameType => (
+									<option key={gameType} value={gameType}>{gameType}</option>
+								))}
+							</select>
+						</p>
+						<p>Ranks:<input type="range" value={this.state.ranks} min={2} max={16} onChange={this._onRanksChanged.bind(this)} /> {this.state.ranks}</p>
+						<p>Files:<input type="range" value={this.state.files} min={2} max={16} onChange={this._onFilesChanged.bind(this)} /> {this.state.files}</p>
+					</div>
 					<p/>
 				</div>
 					<Chessdiagram flip={this.state.flip} fen={this.state.currentPosition} squareSize={this.state.squareSize}
 						lightSquareColor={this.state.lightSquareColor} darkSquareColor={this.state.darkSquareColor} onMovePiece={this._onMovePiece.bind(this)}
 						ranks={this.state.ranks} files={this.state.files}
-						pieceDefinitions={this.state.draughts ? this.draughtsPieceDefinitions : {}}
+						pieceDefinitions={this.gamePresets[this.state.gameType].pieceDefinitions}
 					/>
-				<p><strong>{this.state.lastMessage}</strong></p>
+				<p className={"lastMessage"}><strong>{this.state.lastMessage}</strong></p>
 			</div>
     );
   }

--- a/src/board.js
+++ b/src/board.js
@@ -34,12 +34,31 @@ class Square extends Component {
 	}
 }
 
+Square.propTypes = {
+	darkSquareColor: React.PropTypes.string.isRequired,
+	light: React.PropTypes.bool.isRequired,
+	lightSquareColor: React.PropTypes.string.isRequired,
+	squareSize: React.PropTypes.number.isRequired,
+	x: React.PropTypes.number.isRequired,
+	y: React.PropTypes.number.isRequired,
+};
+
 class SquareHighlight extends Component {
 	render() {
-		let highlightColor = 'yellow';
-		return <rect x={this.props.x} y={this.props.y} width={this.props.squareSize} height={this.props.squareSize} stroke={highlightColor} fill="none" strokeWidth="3" />;
+		return <rect x={this.props.x} y={this.props.y} width={this.props.squareSize} height={this.props.squareSize} stroke={this.props.highlightColor} fill="none" strokeWidth="3" />;
 	}
 }
+
+SquareHighlight.propTypes = {
+	highlightColor: React.PropTypes.string.isRequired,
+	squareSize: React.PropTypes.number.isRequired,
+	x: React.PropTypes.number.isRequired,
+	y: React.PropTypes.number.isRequired,
+};
+
+SquareHighlight.defaultProps = {
+	highlightColor: 'yellow'
+};
 
 class RankLabels extends Component {
 
@@ -94,6 +113,16 @@ class FileLabels extends Component {
 		);
 	}
 }
+
+const LabelPropTypes = {
+	files: React.PropTypes.number,
+	flip: React.PropTypes.bool.isRequired,
+	ranks: React.PropTypes.number,
+	squareSize: React.PropTypes.number.isRequired,
+};
+
+RankLabels.propTypes = LabelPropTypes;
+FileLabels.propTypes = LabelPropTypes;
 
 /** Board : draws a chess board with given square size, square colors, and number of files and ranks */
 class Board extends Component {
@@ -158,7 +187,7 @@ class Board extends Component {
 			<svg>
 				{squares.map((square,i) =>
 					<Square
-						x={square.x} y={square.y} key={i} light={square.light} squareSize={this.props.squareSize}
+						x={square.x} y={square.y} key={i} light={!!square.light} squareSize={this.props.squareSize}
 						lightSquareColor={this.props.lightSquareColor} darkSquareColor={this.props.darkSquareColor}
 					/>
 				)}
@@ -169,15 +198,16 @@ class Board extends Component {
 			</svg>
 		);
 	}
-}	
+}
 
 Board.propTypes = {
-	darkSquareColor: React.PropTypes.string,
-	files: React.PropTypes.number,
-	flip: React.PropTypes.bool,
-	lightSquareColor: React.PropTypes.string,
-	ranks: React.PropTypes.number,
-	squareSize: React.PropTypes.number,
+	darkSquareColor: React.PropTypes.string.isRequired,
+	files: React.PropTypes.number.isRequired,
+	flip: React.PropTypes.bool.isRequired,
+	lightSquareColor: React.PropTypes.string.isRequired,
+	ranks: React.PropTypes.number.isRequired,
+	selectedSquare: React.PropTypes.string,
+	squareSize: React.PropTypes.number.isRequired,
 };
 
 Board.defaultProps = {

--- a/src/chessdiagram.js
+++ b/src/chessdiagram.js
@@ -27,7 +27,6 @@ SOFTWARE.
 // chessdiagram.js : defines Chess Diagram Component
 
 import React, { Component } from 'react';
-import ReactDOM from 'react-dom';
 import Board from './board.js';
 import Piece from './piece.js';
 import standardPieceDefinitions from './pieceDefinitions.js';
@@ -216,7 +215,7 @@ class Chessdiagram extends Component {
 	// self-enquiry ////
 
 	_getClientPos() {
-		let rect = ReactDOM.findDOMNode(this).getBoundingClientRect();
+		let rect = this.refs.client.getBoundingClientRect();
 		this.setState({left: rect.left, top: rect.top, width: rect.width, height: rect.height});
 	}
 
@@ -279,6 +278,7 @@ class Chessdiagram extends Component {
 					onTouchMove={this._onTouchMove.bind(this)}
 					onMouseUp={this._onMouseUp.bind(this)}
 					onTouchEnd={this._onTouchEnd.bind(this)}
+					ref={"client"}
 				>
 
 					<Board

--- a/src/piece.js
+++ b/src/piece.js
@@ -26,7 +26,6 @@ SOFTWARE.
 
 import React, { Component } from 'react';
 import './piece.css';
-import PieceDefs from './pieceDefinitions';
 
 /** Piece: renders an svg chess piece of a given type and position */
 class Piece extends Component {
@@ -42,12 +41,14 @@ class Piece extends Component {
 	}
 }
 
+// TODO: remove pieceType, only check to see if drawPiece has changed in shouldComponentUpdate
 Piece.propTypes = {
+	drawPiece: React.PropTypes.func.isRequired,
+	pieceType: React.PropTypes.string.isRequired,
+	squareSize: React.PropTypes.number.isRequired,
 	x: React.PropTypes.number.isRequired,
 	y: React.PropTypes.number.isRequired,
 	/** recognized piece types: K,Q,R,B,N,P,k,q,r,b,n,p */
-	pieceType: React.PropTypes.string.isRequired,
-	drawPiece: React.PropTypes.func.isRequired
 };
 
 export default Piece;


### PR DESCRIPTION
Fixes linting errors, and spruces up the demo. Fixing the linting errors are pretty straight forward; the ReactDOM method `findDOMNode` is deprecated and so has been replaced.

The demo has been laid out so that the whole thing is visible on one screen. Custom board sizes were actually introduced in the last pull request, so it's just leveraging existing functionality. Tests for custom board sizes are included in a different pull request.

As an aside, this is my first time contributing to an open source project, and it's super fun!